### PR TITLE
socat DNS Redirector command update

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ socat can be used to redirect incoming DNS packets on port 53 to our team server
 Edit 4/21/2017: 
 The following socat command seems to work well thanks to testing from @xorrior:
 ```
-socat udp4-recvfrom:53,reuseaddr,fork udp4-sendto:<IPADDRESS>; echo -ne
+socat udp4-recvfrom:53,reuseaddr,fork udp4-sendto:<IPADDRESS>:53; echo -ne
 ```
 
 [Redirecting Cobalt Strike DNS Beacons - Steve Borosh](http://www.rvrsh3ll.net/blog/offensive/redirecting-cobalt-strike-dns-beacons/)


### PR DESCRIPTION
I kept getting this error if I did not specify the sendto port in socat
"socat[*] E udp4-sendto: wrong number of parameters (1 instead of 2)"